### PR TITLE
Patch/fix app names

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -69,7 +69,7 @@ const config: ForgeConfig = {
     packagerConfig: {
         appBundleId: 'app.moonslide.desktop',
         name: packageJSON.productName,
-        executableName: packageJSON.productName,
+        executableName: packageJSON.name,
         ...macOSPackagerConfig(),
     },
     rebuildConfig: {},

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -102,7 +102,7 @@ const config: ForgeConfig = {
         new MakerDeb({
             options: {
                 name: packageJSON.name,
-                bin: packageJSON.productName,
+                bin: packageJSON.name,
                 productName: packageJSON.productName,
             },
         }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "moonslide",
-    "version": "0.1.1-beta.3",
+    "version": "0.1.1-beta.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "moonslide",
-            "version": "0.1.1-beta.3",
+            "version": "0.1.1-beta.4",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/commands": "^6.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "moonslide",
-    "version": "0.1.1-beta.2",
+    "version": "0.1.1-beta.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "moonslide",
-            "version": "0.1.1-beta.2",
+            "version": "0.1.1-beta.3",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/commands": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "moonslide",
     "productName": "Moonslide",
-    "version": "0.1.1-beta.3",
+    "version": "0.1.1-beta.4",
     "description": "Editor to create presentations with Markdown and Reveal.js",
     "main": ".vite/build/main.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "moonslide",
     "productName": "Moonslide",
-    "version": "0.1.1-beta.2",
+    "version": "0.1.1-beta.3",
     "description": "Editor to create presentations with Markdown and Reveal.js",
     "main": ".vite/build/main.js",
     "scripts": {


### PR DESCRIPTION
- Fix names such that macOS executable as the expected name `Moonslide.app`
    - `electron-builder` seems to misuse the `executableName` as the `displayName` in `Info.plist`, so `executableName` is set to `packageJSON.productName` which corresponds to "Moonslide".