### PR TITLE
Fix Image Resolution If Presentation Path Contains Spaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "moonslide",
-    "version": "0.1.1",
+    "version": "0.1.2-beta.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "moonslide",
-            "version": "0.1.1",
+            "version": "0.1.2-beta.1",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/commands": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "moonslide",
     "productName": "Moonslide",
-    "version": "0.1.1",
+    "version": "0.1.2-beta.1",
     "description": "Editor to create presentations with Markdown and Reveal.js",
     "main": ".vite/build/main.js",
     "scripts": {

--- a/src-main/parse/imagePath.ts
+++ b/src-main/parse/imagePath.ts
@@ -50,7 +50,7 @@ export function transformImagePath(path: string, request: ParseRequest): LocalIm
     const originalPath = parsedUrl.path
     const resolvedPath = isAbsolute(originalPath)
         ? originalPath
-        : resolve(dirname(request.markdownFilePath), originalPath)
+        : resolve(dirname(request.markdownFilePath), decodeURI(originalPath))
 
     let transformedPath = ''
     let requiredCopyAction: RequiredCopyAction | undefined = undefined
@@ -69,6 +69,7 @@ export function transformImagePath(path: string, request: ParseRequest): LocalIm
         else transformedPath = relativeWithForwardSlash(request.outputFolderPath, resolvedPath)
     }
 
+    transformedPath = encodeURI(transformedPath)
     return { originalPath, resolvedPath, transformedPath, requiredCopyAction }
 }
 

--- a/src-main/parse/transformTokens.ts
+++ b/src-main/parse/transformTokens.ts
@@ -96,7 +96,7 @@ function replaceBgImages(tokens: Token[]): Token[] {
         const src = token.attrGet('src') ?? ''
         token.attrs.splice(token.attrIndex('src'), 1)
 
-        const style = joinStyles(token.attrGet('style'), `background-image: url(${src});`)
+        const style = joinStyles(token.attrGet('style'), `background-image: url('${src}');`)
         token.attrSet('style', style)
 
         const closingTag = new Token('image_closing_tag', 'div', -1)


### PR DESCRIPTION
- Fixes resolution of images if path to presentation contains spaces
    - Add single quotes around `background-image` tag
    - Call `encodeURI` in `transformImagePath` on `transformedPath` such that the _whole_ transformed path is URI encoded
    - Call `decodeURI` when resolving image from original path such that the _whole_ resolved path is URI decoded

Closes #118 